### PR TITLE
Changing snapcraft.yaml to use the PPA, Kvantum and the kde-neon-6 extension

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,48 +21,62 @@ compression: lzo
 apps:
   quickbib:
     command: usr/bin/quickbib
+    desktop: usr/share/applications/io.github.archisman_panigrahi.QuickBib.desktop
     environment:
-      PYTHONPATH: $SNAP/usr/lib/python3/site-packages:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
-      QT_PLUGIN_PATH: ${SNAP}/usr/lib/x86_64-linux-gnu/qt6/plugins
-      QT_QPA_PLATFORM_PLUGIN_PATH: ${SNAP}/usr/lib/x86_64-linux-gnu/qt6/plugins/platforms
-      # SNAP_DESKTOP_RUNTIME: $SNAP/kf6
-      # QT_VERSION: "6"
-      # XDG_DATA_DIRS: $SNAP/usr/share:${XDG_DATA_DIRS:+:$XDG_DATA_DIRS}
-    plugs:
-      - network
-      - x11
-      - wayland
+      PYTHONPATH: $SNAP/usr/lib/python3/dist-packages:$PYTHONPATH
+      QT_QPA_PLATFORMTHEME: xdgdesktopportal
+      LD_LIBRARY_PATH: $SNAP/lxqt-support/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR:$LD_LIBRARY_PATH
+      QT_PLUGIN_PATH: $SNAP/lxqt-support/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/qt6/plugins:$QT_PLUGIN_PATH
+    extensions: [kde-neon-6]
+
+plugs:
+  lxqt-support:
+    content: lxqt-support
+    interface: content
+    target: $SNAP/lxqt-support
+    default-provider: lxqt-support
+
+layout:
+  /usr/share/color-schemes:
+    symlink: $SNAP/lxqt-support/usr/share/color-schemes
+  /usr/share/Kvantum:
+    symlink: $SNAP/lxqt-support/usr/share/Kvantum
+
+package-repositories:
+  - type: apt
+    url: https://ppa.launchpadcontent.net/apandada1/quickbib/ubuntu
+    suites: [noble]
+    components: [main]
+    architectures: [arm64, amd64]
+    key-id: 4BDCA6FAF8BE2B807944B40C9E776C57AA2476B8
 
 parts:
   quickbib:
-    plugin: meson
-    # Track the latest code from the GitHub repository (HEAD of `main` branch).
-    # Use a shallow clone (source-depth: 1) to fetch the latest commit quickly.
-    source: https://github.com/archisman-panigrahi/QuickBib.git
-    source-branch: main
-    source-depth: 1
-    build-packages:
-      - python3-dev
-      - pkg-config
-      - build-essential
-      - meson
-      - ninja-build
+    plugin: nil
     stage-packages:
-      - python3
+      - quickbib
+      - python3-doi2bib3
       - python3-pyqt6
-    meson-parameters:
-      - --prefix=/snap/quickbib/current/usr
-      - -Dbuildtype=release
-    organize:
-      snap/quickbib/current: .
-
-  python-deps:
-    plugin: python
-    source: ..
-    python-packages:
-      - doi2bib3
-    stage-packages:
-      - python3
+      - python3-bibtexparser
+      - python3-pyparsing
+    override-build: |
+      craftctl default
+      sed -e 's|Exec=quickbib %U|Exec=${SNAP}/usr/bin/quickbib %U|' -i  $CRAFT_PART_INSTALL/usr/share/applications/io.github.archisman_panigrahi.QuickBib.desktop
+      sed -e 's|Icon=io.github.archisman_panigrahi.QuickBib|Icon=${SNAP}/usr/share/icons/hicolor/scalable/apps/io.github.archisman_panigrahi.QuickBib.svg|' -i  $CRAFT_PART_INSTALL/usr/share/applications/io.github.archisman_panigrahi.QuickBib.desktop
+    prime:
+      - usr/bin/doi2bib3
+      - usr/bin/quickbib
+      - usr/lib/python3/dist-packages/doi2bib3
+      - usr/lib/python3/dist-packages/PyQt6
+      - usr/lib/python3/dist-packages/bibtexparser
+      - usr/lib/python3/dist-packages/pyparsing
+      - usr/share/applications/io.github.archisman_panigrahi.QuickBib.desktop
+      - usr/share/doc/python3-doi2bib3
+      - usr/share/doc/quickbib
+      - usr/share/icons/hicolor/*/apps/io.github.archisman_panigrahi.QuickBib.svg
+      - usr/share/metainfo/io.github.archisman_panigrahi.QuickBib.metainfo.xml
+      - usr/share/python3/runtime.d/quickbib.rtupdate
+      - usr/share/quickbib
 
 lint:
   ignore:


### PR DESCRIPTION
I made some changes to snapcraft.yaml. I saw that your app is available in a PPA, so now the Snap version is created using it.

I added the use of the kde-neon-6 extension, which connects your app to the kf6-core24 content Snap. This allows it to access various dependencies instead of putting them all inside your app's Snap package.

I also added the use of lxqt-support, which is a Snap content that provides Kvantum, but since Snap apps currently do not have access to .config/Kvantum by default, to change the Kvantum theme, you need to copy this folder into the .config folder of your Snap app.

https://github.com/user-attachments/assets/e7353547-575b-4fcd-9676-032d7e88e322