### PR TITLE
Revert "[WIP] Update snapcraft.yaml to restrict builds to amd64 and arm64"

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -17,13 +17,6 @@ confinement: strict
 base: core24
 compression: lzo
 
-architectures:
-  - build-on: amd64
-    run-on:
-      - amd64
-  - build-on: arm64
-    run-on:
-      - arm64
 
 apps:
   quickbib:


### PR DESCRIPTION
Reverts archisman-panigrahi/QuickBib#5

Turns out it caused build failure